### PR TITLE
Fix REAME to | NSStringScoreOptions together, not & them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ CGFloat result1 = [testString scoreAgainst:@"Hello world!"];
 CGFloat result2 = [testString scoreAgainst:@"world"];
 CGFloat result3 = [testString scoreAgainst:@"wXrld" fuzziness:[NSNumber numberWithFloat:0.8]];
 CGFloat result4 = [testString scoreAgainst:@"world" fuzziness:nil options:NSStringScoreOptionFavorSmallerWords];
-CGFloat result5 = [testString scoreAgainst:@"world" fuzziness:nil options:(NSStringScoreOptionFavorSmallerWords & NSStringScoreOptionReducedLongStringPenalty)];
+CGFloat result5 = [testString scoreAgainst:@"world" fuzziness:nil options:(NSStringScoreOptionFavorSmallerWords | NSStringScoreOptionReducedLongStringPenalty)];
 CGFloat result6 = [testString scoreAgainst:@"HW"]; // abbreviation matching example
 
 NSLog(@"Result 1 = %f", result1);


### PR DESCRIPTION
The README was &ing the NSStringScoreOptions together. 
The | operator is used to combine, & wouldn't match against either of them.

I didn't test to see if the output was different though.
