### PR TITLE
Imported core graphics at the top of NSString+Score.h since Foundation...

### DIFF
--- a/NSString+Score.h
+++ b/NSString+Score.h
@@ -6,6 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 enum{
     NSStringScoreOptionNone                         = 1 << 0,


### PR DESCRIPTION
...doesn't seem to include the typedef for CGFloat.
